### PR TITLE
Restrict access using GitHub authentication

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,8 @@ gem 'coffee-rails', '~> 4.0.0'
 gem 'jquery-rails'
 gem 'bootstrap-sass', '~> 3.2.0'
 
+gem 'warden-github-rails', '~> 1.1.0'
+
 group :development do
   gem 'spring'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,6 +27,7 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.1)
       tzinfo (~> 1.1)
+    addressable (2.3.6)
     arel (5.0.1.20140414130214)
     bootstrap-sass (3.2.0.0)
       sass (~> 3.2)
@@ -41,6 +42,8 @@ GEM
     diff-lcs (1.2.5)
     erubis (2.7.0)
     execjs (2.2.1)
+    faraday (0.9.0)
+      multipart-post (>= 1.2, < 3)
     hike (1.2.3)
     i18n (0.6.11)
     jquery-rails (3.1.1)
@@ -53,6 +56,9 @@ GEM
     mime-types (1.25.1)
     minitest (5.4.0)
     multi_json (1.10.1)
+    multipart-post (2.0.0)
+    octokit (3.2.0)
+      sawyer (~> 0.5.3)
     pg (0.17.1)
     polyglot (0.3.5)
     rack (1.5.2)
@@ -96,6 +102,9 @@ GEM
       sass (~> 3.2.0)
       sprockets (~> 2.8, <= 2.11.0)
       sprockets-rails (~> 2.0)
+    sawyer (0.5.4)
+      addressable (~> 2.3.5)
+      faraday (~> 0.8, < 0.10)
     shoulda-matchers (2.6.2)
       activesupport (>= 3.0.0)
     spring (1.1.3)
@@ -119,6 +128,14 @@ GEM
     uglifier (2.5.3)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
+    warden (1.2.3)
+      rack (>= 1.0)
+    warden-github (1.0.1)
+      octokit (> 2.1.0)
+      warden (> 1.0)
+    warden-github-rails (1.1.0)
+      railties (>= 3.1)
+      warden-github (~> 1.0)
 
 PLATFORMS
   ruby
@@ -134,3 +151,4 @@ DEPENDENCIES
   shoulda-matchers
   spring
   uglifier (>= 1.3.0)
+  warden-github-rails (~> 1.1.0)

--- a/config/initializers/cookies_serializer.rb
+++ b/config/initializers/cookies_serializer.rb
@@ -1,3 +1,3 @@
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.action_dispatch.cookies_serializer = :json
+Rails.application.config.action_dispatch.cookies_serializer = :marshal

--- a/config/initializers/warden_github_rails.rb
+++ b/config/initializers/warden_github_rails.rb
@@ -1,0 +1,8 @@
+Warden::GitHub::Rails.setup do |config|
+  config.add_scope :user,
+    client_id: ENV['GITHUB_CLIENT_ID'],
+    client_secret: ENV['GITHUB_CLIENT_SECRET'],
+    scope: 'user:email,read:org'
+
+  config.default_scope = :user
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
-  root to: redirect(path: '/incidents', status: 302)
+  github_authenticate(org: ENV['GITHUB_ORG']) do
+    root to: redirect(path: '/incidents', status: 302)
 
-  resources :incidents, except: :destroy
+    resources :incidents, except: :destroy
+  end
 end


### PR DESCRIPTION
This will only allow access to users in a certain GitHub organisation. The GitHub application and organisation to use are configurable via environment variables.

The `warden-github-rails` gem stores the authenticated GitHub user's details in the session. Rails 4.1 changes the default session store to be JSON-based, which isn't capable of storing complex objects. I've switched back to the old Marshal-based session store to make it work.
