### PR TITLE
Update incident status from show page

### DIFF
--- a/app/assets/javascripts/incident.coffee
+++ b/app/assets/javascripts/incident.coffee
@@ -6,6 +6,9 @@ $(document).on("page:change", ->
   )
   commentsEl = $("#comments-container")[0]
   Comments.initComments(commentsEl) if commentsEl
+
+  $('#incident-status').change ->
+    $(this).closest('form').submit()
 )
 
 Comments =

--- a/app/controllers/incidents_controller.rb
+++ b/app/controllers/incidents_controller.rb
@@ -1,5 +1,5 @@
 class IncidentsController < ApplicationController
-  before_action :set_incident, only: [:show, :edit, :update]
+  before_action :set_incident, only: [:show, :edit, :update, :status]
 
   def index
     @incidents = Incident.order(id: :desc)
@@ -31,6 +31,14 @@ class IncidentsController < ApplicationController
       redirect_to @incident, notice: 'Incident was successfully updated.'
     else
       render :edit
+    end
+  end
+
+  def status
+    if @incident.update(params.permit(:status))
+      redirect_to @incident, notice: 'Incident status successfully updated.'
+    else
+      redirect_to @incident, flash: { :error => 'Incident status could not be updated!' }
     end
   end
 

--- a/app/views/incidents/show.html.erb
+++ b/app/views/incidents/show.html.erb
@@ -15,8 +15,10 @@
 </p>
 
 <p>
-  <strong>Status:</strong>
-  <%= @incident.status %>
+  <%= form_tag(status_incident_path, method: :patch, class: 'form-inline') do |f| %>
+    <%= label_tag :status, "Status:" %>
+    <%= select_tag :status, options_for_select(Incident::STATUS_VALUES, @incident.status), id: 'incident-status', class: 'form-control' %>
+  <% end %>
 </p>
 
 <p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,8 @@ Rails.application.routes.draw do
 
     resources :incidents, except: :destroy do
       resources :comments, only: [:new, :create, :index]
+
+      patch :status, on: :member
     end
   end
 end

--- a/spec/controllers/incidents_controller_spec.rb
+++ b/spec/controllers/incidents_controller_spec.rb
@@ -119,4 +119,32 @@ RSpec.describe IncidentsController, type: :controller do
     end
   end
 
+  describe "PATCH status" do
+    describe "with valid params" do
+      it "updates the incident's status" do
+        patch :status, { id: incident.to_param, status: "closed" }
+        incident.reload
+        expect(incident.status).to eq("closed")
+      end
+
+      it "redirects to the incident" do
+        patch :status, { id: incident.to_param, status: "closed" }
+        expect(response).to redirect_to(incident)
+      end
+    end
+
+    describe "with invalid params" do
+      it "doesn't update the incident's status" do
+        patch :status, { id: incident.to_param, status: "bad_status" }
+        incident.reload
+        expect(incident.status).to eq("open")
+      end
+
+      it "redirects to the incident" do
+        patch :status, { id: incident.to_param, status: "bad_status" }
+        expect(response).to redirect_to(incident)
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
There is now a dropdown to update an incident's status on the show page.
