### PR TITLE
Use rails_12factor gem when running on Heroku

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,3 +28,7 @@ group :test do
   gem 'simplecov', require: false
   gem 'coveralls', require: false
 end
+
+group :production do
+  gem 'rails_12factor', require: false
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,6 +89,11 @@ GEM
       bundler (>= 1.3.0, < 2.0)
       railties (= 4.1.4)
       sprockets-rails (~> 2.0)
+    rails_12factor (0.0.2)
+      rails_serve_static_assets
+      rails_stdout_logging
+    rails_serve_static_assets (0.0.2)
+    rails_stdout_logging (0.0.3)
     railties (4.1.4)
       actionpack (= 4.1.4)
       activesupport (= 4.1.4)
@@ -177,6 +182,7 @@ DEPENDENCIES
   pg
   puma
   rails (= 4.1.4)
+  rails_12factor
   rspec-rails (~> 3.0.0)
   sass-rails (~> 4.0.3)
   shoulda-matchers

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -19,8 +19,8 @@ Rails.application.configure do
   # For large-scale production use, consider using a caching reverse proxy like nginx, varnish or squid.
   # config.action_dispatch.rack_cache = true
 
-  # Enable Rails's static asset server (required to run on Heroku).
-  config.serve_static_assets = true
+  # Disable Rails's static asset server (Apache or nginx will already do this).
+  config.serve_static_assets = false
 
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = :uglifier

--- a/config/initializers/heroku_logging.rb
+++ b/config/initializers/heroku_logging.rb
@@ -1,0 +1,4 @@
+# This gem is only necessary when running on Heroku.
+if Rails.env.production? && ENV.keys.any? { |key| key.match(/^HEROKU/) }
+  require 'rails_12factor'
+end


### PR DESCRIPTION
Heroku provide a gem which modifies your app's configuration for better compatibility with their platform. It sets up the Rails logger to write to STDOUT, and enables some Rack middleware to serve static assets.

I'd like these things to work when running on Heroku, but I also don't want to make it harder to run Banjaxed on other platforms. Here the gem will only be required if it looks we're running on Heroku, based on the environment variables present.

This reverts 5948ec47b08c8ee4826829870f039f7f90629f97, which I did last week to make assets work, in favour of letting the gem take care of it.
