### PR TITLE
Fix for severity value when editing

### DIFF
--- a/app/views/incidents/_form.html.erb
+++ b/app/views/incidents/_form.html.erb
@@ -21,7 +21,7 @@
   </div>
   <div class="form-group">
     <%= f.label :severity %><br>
-    <%= f.select :severity, options_for_select(Incident::SEVERITY_VALUES), {}, class: 'form-control' %>
+    <%= f.select :severity, options_for_select(Incident::SEVERITY_VALUES, @incident.severity), {}, class: 'form-control' %>
   </div>
   <div class="form-group">
     <%= f.label :started_at %><br>


### PR DESCRIPTION
Currently when you edit an incident it defaults to critical. This change means
that it will show the saved value by default.
