### PR TITLE
Preserve newlines in descriptions and comments

### DIFF
--- a/app/assets/javascripts/incident.coffee
+++ b/app/assets/javascripts/incident.coffee
@@ -67,13 +67,14 @@ class CommentsList
   commentHTML: (comment) ->
     commentTime = new Date(comment.created_at)
     timeString = commentTime.toLocaleString()
+    commentContent = comment.content.split("\n").join("<br />")
     """
       <div class="panel panel-default">
         <div class="panel-heading"><small>
           #{comment.user.name}
           <span class="pull-right text-muted">#{timeString}</span>
         </small></div>
-        <div class="panel-body">#{comment.content}</div>
+        <div class="panel-body">#{commentContent}</div>
       </div>
     """
 

--- a/app/views/incidents/show.html.erb
+++ b/app/views/incidents/show.html.erb
@@ -5,9 +5,7 @@
   <%= @incident.title %>
 </h1>
 
-<p class="lead">
-  <%= @incident.description %>
-</p>
+<%= simple_format(@incident.description, class: 'lead') %>
 
 <p>
   <strong>Severity:</strong>


### PR DESCRIPTION
This formats the incident description using Rails' simple_format helper, which converts newlines into paragraphs and line break tags.

Comments are rendered in JavaScript, so they're handled separately using string substitution. Hopefully this will be superseded by Markdown support in future, but this will make things more usable until then.
