### PR TITLE
Filter incidents by status

### DIFF
--- a/app/assets/stylesheets/incidents.css.scss
+++ b/app/assets/stylesheets/incidents.css.scss
@@ -1,3 +1,7 @@
+#incident-status-switcher {
+   margin-top: 20px;
+}
+
 .new_incident, .edit_incident {
   max-width: 600px;
 }

--- a/app/controllers/incidents_controller.rb
+++ b/app/controllers/incidents_controller.rb
@@ -3,6 +3,10 @@ class IncidentsController < ApplicationController
 
   def index
     @incidents = Incident.order(id: :desc)
+
+    if params.key?(:status) && Incident::STATUS_VALUES.include?(params[:status])
+      @incidents = @incidents.where(status: params[:status])
+    end
   end
 
   def show

--- a/app/helpers/incidents_helper.rb
+++ b/app/helpers/incidents_helper.rb
@@ -8,4 +8,12 @@ module IncidentsHelper
 
     content_tag :span, incident.severity.upcase, class: "label label-#{label_class}"
   end
+
+  def incident_status_switcher_item(status, label, active_status)
+    options = status == active_status ? { class: 'active' } : {}
+
+    content_tag :li, options do
+      link_to label, incidents_path(status: status)
+    end
+  end
 end

--- a/app/views/incidents/index.html.erb
+++ b/app/views/incidents/index.html.erb
@@ -1,4 +1,11 @@
-<h1>Listing incidents</h1>
+<h1 class="pull-left">Listing incidents</h1>
+
+<ul id="incident-status-switcher" class="nav nav-pills pull-right">
+  <% Incident::STATUS_VALUES.each do |status| %>
+    <%= incident_status_switcher_item(status, status.capitalize, params[:status]) %>
+  <% end %>
+  <%= incident_status_switcher_item(nil, "All", params[:status]) %>
+</ul>
 
 <table class="table table-striped">
   <thead>

--- a/spec/controllers/incidents_controller_spec.rb
+++ b/spec/controllers/incidents_controller_spec.rb
@@ -23,9 +23,29 @@ RSpec.describe IncidentsController, type: :controller do
   }
 
   describe "GET index" do
-    it "assigns all incidents as @incidents" do
-      get :index, {}
-      expect(assigns(:incidents)).to eq([incident])
+    let!(:closed_incident) {
+      FactoryGirl.create(:incident, status: 'closed')
+    }
+
+    context "with no status parameter" do
+      it "assigns all incidents as @incidents" do
+        get :index, {}
+        expect(assigns(:incidents)).to eq([incident, closed_incident])
+      end
+    end
+
+    context "with a closed status parameter" do
+      it "assigns only closed incidents as @incidents" do
+        get :index, { status: 'closed' }
+        expect(assigns(:incidents)).to eq([closed_incident])
+      end
+    end
+
+    context "with an invalid status parameter" do
+      it "ignores the status parameter and assigns all incidents as @incidents" do
+        get :index, { status: 'something' }
+        expect(assigns(:incidents)).to eq([incident, closed_incident])
+      end
     end
   end
 

--- a/spec/factories/incidents.rb
+++ b/spec/factories/incidents.rb
@@ -3,6 +3,7 @@ FactoryGirl.define do
     title "Something is wrong"
     description "We should investigate"
     severity 'high'
+    status 'open'
     user
   end
 end

--- a/spec/helpers/incidents_helper_spec.rb
+++ b/spec/helpers/incidents_helper_spec.rb
@@ -28,4 +28,46 @@ RSpec.describe IncidentsHelper, type: :helper do
       end
     end
   end
+
+  describe '#incident_status_switcher_item' do
+    subject(:switcher_item) {
+      helper.incident_status_switcher_item(status, "label", active_status)
+    }
+
+    context "when status is present" do
+      let(:status) { 'open' }
+      let(:active_status) { nil }
+
+      it "outputs a link to incidents filtered by status" do
+        expect(switcher_item).to match(/href="\/incidents\?status=open"/)
+      end
+    end
+
+    context "when status is not present" do
+      let(:status) { nil }
+      let(:active_status) { nil }
+
+      it "outputs a link to all incidents" do
+        expect(switcher_item).to match(/href="\/incidents"/)
+      end
+    end
+
+    context "when active_status matches status" do
+      let(:status) { 'open' }
+      let(:active_status) { 'open' }
+
+      it "adds the active class to the list item" do
+        expect(switcher_item).to match(/<li class="active">/)
+      end
+    end
+
+    context "when active_status doesn't match status" do
+      let(:status) { 'open' }
+      let(:active_status) { 'closed' }
+
+      it "doesn't add the active class to the list item" do
+        expect(switcher_item).not_to match(/<li class="active">/)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Adds a toggle on the incident listing page to view incidents with a particular status, or all incidents.
