### PR TITLE
Move incident details to a side panel

### DIFF
--- a/app/views/incidents/_details.html.erb
+++ b/app/views/incidents/_details.html.erb
@@ -1,0 +1,30 @@
+<div class="panel panel-default">
+  <div class="panel-heading">
+    Incident details
+  </div>
+
+  <div class="panel-body">
+    <%= form_tag(status_incident_path, method: :patch, class: 'form-inline') do |f| %>
+      <%= label_tag :status, "Status:" %>
+      <%= select_tag :status, options_for_select(Incident::STATUS_VALUES, incident.status), id: 'incident-status', class: 'form-control' %>
+    <% end %>
+
+    <br>
+
+    <p>
+      <strong>Opened by:</strong>
+      <%= incident.user.name %>
+    </p>
+
+    <p>
+      <strong>Started at:</strong>
+      <%= incident.started_at %>
+    </p>
+
+    <p>
+      <strong>Detected at:</strong>
+      <%= incident.detected_at %>
+    </p>
+
+  </div>
+</div>

--- a/app/views/incidents/show.html.erb
+++ b/app/views/incidents/show.html.erb
@@ -6,31 +6,17 @@
   <%= @incident.title %>
 </h1>
 
-<%= simple_format(@incident.description, class: 'lead') %>
+<div class="row">
+  <div class="col-md-8">
+    <%= simple_format(@incident.description, class: 'lead') %>
 
-<p>
-  <%= form_tag(status_incident_path, method: :patch, class: 'form-inline') do |f| %>
-    <%= label_tag :status, "Status:" %>
-    <%= select_tag :status, options_for_select(Incident::STATUS_VALUES, @incident.status), id: 'incident-status', class: 'form-control' %>
-  <% end %>
-</p>
+    <%= link_to 'Edit', edit_incident_path(@incident), class: 'btn btn-default' %>
+  </div>
 
-<p>
-  <strong>Opened by:</strong>
-  <%= @incident.user.name %>
-</p>
-
-<p>
-  <strong>Started at:</strong>
-  <%= @incident.started_at %>
-</p>
-
-<p>
-  <strong>Detected at:</strong>
-  <%= @incident.detected_at %>
-</p>
-
-<%= link_to 'Edit', edit_incident_path(@incident), class: 'btn btn-default' %>
+  <div class="col-md-4">
+    <%= render partial: 'details', locals: { incident: @incident } %>
+  </div>
+</div>
 
 <div id="comments-container" data-incident-id="<%= @incident.id %>">
   <header>


### PR DESCRIPTION
An incident's status, opener, start time and detect time are now shown in a panel on the right hand side, which leaves more room for comments.
