### PR TITLE
Update GitHub user details on sign in

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,10 +6,12 @@ class User < ActiveRecord::Base
   has_many :comments
 
   def self.create_or_update_from_github_user(github_user)
-    self.where(github_id: github_user.id).first_or_create!(
-      github_username: github_user.login,
-      name: github_user.name,
-      gravatar_hash: github_user.gravatar_id
-    )
+    self.find_or_initialize_by(github_id: github_user.id).tap do |user|
+      user.update!(
+        github_username: github_user.login,
+        name: github_user.name,
+        gravatar_hash: github_user.gravatar_id
+      )
+    end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -33,7 +33,9 @@ RSpec.describe User, type: :model do
     end
 
     context "with an existing user" do
-      let!(:existing_user) { FactoryGirl.create(:user, github_id: 1) }
+      let!(:existing_user) do
+        FactoryGirl.create(:user, github_id: 1, github_username: 'old_user')
+      end
 
       it "doesn't create a new user" do
         expect {
@@ -44,6 +46,11 @@ RSpec.describe User, type: :model do
       it "returns the existing user" do
         user = User.create_or_update_from_github_user(github_user)
         expect(user).to eq(existing_user)
+      end
+
+      it "updates the user's attributes" do
+        user = User.create_or_update_from_github_user(github_user)
+        expect(user.github_username).to eq('some_user')
       end
     end
   end


### PR DESCRIPTION
The `User.create_or_update_from_github_user` method was finding and returning existing users without updating them.

Now after a user authenticates with GitHub, any changes to their username, full name or gravatar since their last visit are applied.
