### PR TITLE
Increase padding on comments, include user avatars

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -18,7 +18,7 @@
 @import "bootstrap";
 
 .nav-avatar {
-  border-radius: 20px;
+  border-radius: 50%;
   border: 1px #e7e7e7 solid;
   margin: -10px 0;
 }

--- a/app/assets/stylesheets/incidents.css.scss
+++ b/app/assets/stylesheets/incidents.css.scss
@@ -23,12 +23,8 @@
     }
   }
   .panel {
-    margin-bottom: 4px;
-    .panel-heading {
-      padding: 0 7px;
-    }
     .panel-body {
-      padding: 7px;
+      padding: 15px 15px 5px 15px;
     }
   }
 }

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -1,7 +1,8 @@
 <div class="panel panel-default" data-comment-id="<%= comment.id %>">
-  <div class="panel-heading"><small>
+  <div class="panel-heading">
+    <%= user_avatar(comment.user, 25) %>
     <%= comment.user.name %>
     <span class="pull-right text-muted"><%= comment.created_at %></span>
-  </small></div>
+  </div>
   <div class="panel-body"><%= simple_format(comment.content) %></div>
 </div>


### PR DESCRIPTION
This makes comments a little nicer to look at.
### Before:

![screen shot 2014-11-13 at 00 44 41](https://cloud.githubusercontent.com/assets/432189/5021519/8eed5e06-6ace-11e4-9cda-6804d93d9ad1.png)
### After:

![screen shot 2014-11-13 at 00 45 17](https://cloud.githubusercontent.com/assets/432189/5021520/8ef21c16-6ace-11e4-9bb3-e95770992054.png)
