### PR TITLE
Use html-pipeline on comments and descriptions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,11 @@ gem 'bootstrap-sass', '~> 3.3.0'
 gem 'warden-github-rails', '~> 1.1.0'
 gem 'sentry-raven'
 
+gem 'html-pipeline', require: 'html/pipeline'
+gem 'github-markdown', '~> 0.5', require: false
+gem 'sanitize', '~> 2.0', require: false
+gem 'rinku', '~> 1.7', require: false
+
 group :development do
   gem 'spring'
   gem 'puma'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,7 +56,11 @@ GEM
       railties (>= 3.0.0)
     faraday (0.9.0)
       multipart-post (>= 1.2, < 3)
+    github-markdown (0.6.7)
     hike (1.2.3)
+    html-pipeline (1.11.0)
+      activesupport (>= 2)
+      nokogiri (~> 1.4)
     i18n (0.6.11)
     jquery-rails (3.1.2)
       railties (>= 3.0, < 5.0)
@@ -65,10 +69,13 @@ GEM
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
     mime-types (2.4.3)
+    mini_portile (0.6.1)
     minitest (5.4.3)
     multi_json (1.10.1)
     multipart-post (2.0.0)
     netrc (0.8.0)
+    nokogiri (1.6.4.1)
+      mini_portile (~> 0.6.0)
     octokit (3.5.2)
       sawyer (~> 0.5.3)
     pg (0.17.1)
@@ -101,6 +108,7 @@ GEM
     rest-client (1.7.2)
       mime-types (>= 1.16, < 3.0)
       netrc (~> 0.7)
+    rinku (1.7.3)
     rspec-core (3.1.7)
       rspec-support (~> 3.1.0)
     rspec-expectations (3.1.2)
@@ -117,6 +125,8 @@ GEM
       rspec-mocks (~> 3.1.0)
       rspec-support (~> 3.1.0)
     rspec-support (3.1.2)
+    sanitize (2.1.0)
+      nokogiri (>= 1.4.4)
     sass (3.2.19)
     sass-rails (4.0.4)
       railties (>= 4.0.0, < 5.0)
@@ -175,12 +185,16 @@ DEPENDENCIES
   coffee-rails (~> 4.1.0)
   coveralls
   factory_girl_rails
+  github-markdown (~> 0.5)
+  html-pipeline
   jquery-rails
   pg
   puma
   rails (= 4.1.7)
   rails_12factor
+  rinku (~> 1.7)
   rspec-rails (~> 3.1.0)
+  sanitize (~> 2.0)
   sass-rails (~> 4.0.3)
   sentry-raven
   shoulda-matchers

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,12 @@
 module ApplicationHelper
+  def render_user_content(content)
+    pipeline = HTML::Pipeline.new [
+      HTML::Pipeline::MarkdownFilter,
+      HTML::Pipeline::SanitizationFilter,
+      HTML::Pipeline::AutolinkFilter
+    ]
+
+    result = pipeline.call(content)
+    result[:output].to_s.html_safe
+  end
 end

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -4,5 +4,5 @@
     <%= comment.user.name %>
     <span class="pull-right text-muted"><%= comment.created_at %></span>
   </div>
-  <div class="panel-body"><%= simple_format(comment.content) %></div>
+  <div class="panel-body"><%= render_user_content(comment.content) %></div>
 </div>

--- a/app/views/incidents/show.html.erb
+++ b/app/views/incidents/show.html.erb
@@ -8,7 +8,9 @@
 
 <div class="row">
   <div class="col-md-8">
-    <%= simple_format(@incident.description, class: 'lead incident-description') %>
+    <div class="lead incident-description">
+      <%= render_user_content(@incident.description) %>
+    </div>
 
     <%= link_to 'Edit', edit_incident_path(@incident), class: 'btn btn-default' %>
   </div>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe ApplicationHelper, type: :helper do
+  describe '#render_user_content' do
+    subject(:rendered_content) { helper.render_user_content(content) }
+
+    context "given Markdown" do
+      let(:content) { "# incident title" }
+
+      it "renders Markdown as HTML" do
+        expect(rendered_content).to eq("<h1>incident title</h1>")
+      end
+    end
+
+    context "given unsafe content" do
+      let(:content) { '<script>alert(document.cookie)</script>' }
+
+      it "sanitizes the content" do
+        expect(rendered_content).to eq("")
+      end
+    end
+
+    context "given plaintext URLs" do
+      let(:content) { 'http://butt.holdings' }
+
+      it "converts URLs into HTML links" do
+        expect(rendered_content).to eq('<p><a href="http://butt.holdings">http://butt.holdings</a></p>')
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://github.com/jch/html-pipeline

This will process Markdown, sanitize content and autolink URLs in incident descriptions and comments.
